### PR TITLE
Remove dangerous dynamic atom creation

### DIFF
--- a/lib/web_push_elixir.ex
+++ b/lib/web_push_elixir.ex
@@ -111,8 +111,8 @@ defmodule WebPushElixir do
     vapid_public_key = url_decode(Application.get_env(:web_push_elixir, :vapid_public_key))
     vapid_private_key = url_decode(Application.get_env(:web_push_elixir, :vapid_private_key))
 
-    %{endpoint: endpoint, keys: %{p256dh: p256dh, auth: auth}} =
-      Jason.decode!(subscription, keys: :atoms)
+    %{"endpoint" => endpoint, "keys" => %{"p256dh" => p256dh, "auth" => auth}} =
+      Jason.decode!(subscription)
 
     encrypted_payload = encrypt_payload(message, p256dh, auth)
 


### PR DESCRIPTION
When using `keys: :atoms`, keys are converted to atoms using `String.to_atom/1`.

This is potentially dangerous, especially if subscription maps are persisted "as is" from the client and then used for the web push.

This is a small change and I do not think it will affect anything else.