### PR TITLE
Add additional message options (ttl, urgency, topic)

### DIFF
--- a/lib/web_push_elixir.ex
+++ b/lib/web_push_elixir.ex
@@ -102,6 +102,10 @@ defmodule WebPushElixir do
 
   * `subscription` - the subscription JSON string received from the client
   * `message` - the message string to send
+  * `opts` - Optional message options, currently:
+      * `ttl`: time to live in seconds if the client is disconnected, defaults to 60 seconds
+      * `urgency`: Urgency of the message, one of: `:very-low`, `:low`, `:normal`, `:high`
+      * `topic`: a string with a topic, that is used to replace previous same topic notifications
 
   ## Examples
 
@@ -122,9 +126,13 @@ defmodule WebPushElixir do
   * `{:error, :expired}` - subscription expired/not found (HTTP 404 or 410)
   * `{:error, {:http_error, status, body}}` - HTTP error from push service
   """
-  def send_notification(subscription, message) do
+  def send_notification(subscription, message, opts \\ []) when is_list(opts) do
     vapid_public_key = url_decode(Application.get_env(:web_push_elixir, :vapid_public_key))
     vapid_private_key = url_decode(Application.get_env(:web_push_elixir, :vapid_private_key))
+
+    ttl = Keyword.get(opts, :ttl, 60)
+    urgency = Keyword.get(opts, :urgency, nil)
+    topic = Keyword.get(opts, :topic, nil)
 
     %{"endpoint" => endpoint, "keys" => %{"p256dh" => p256dh, "auth" => auth}} =
       Jason.decode!(subscription)
@@ -134,19 +142,24 @@ defmodule WebPushElixir do
     signed_json_web_token =
       sign_json_web_token(endpoint, vapid_public_key, vapid_private_key)
 
+    headers = [
+      {"authorization", "WebPush #{signed_json_web_token}"},
+      {"content-encoding", "aesgcm"},
+      {"content-length", "#{byte_size(encrypted_payload.ciphertext)}"},
+      {"content-type", "application/octet-stream"},
+      {"crypto-key", "dh=#{url_encode(encrypted_payload.local_public_key)};p256ecdsa=#{url_encode(vapid_public_key)}"},
+      {"encryption", "salt=#{url_encode(encrypted_payload.salt)}"},
+      {"ttl", "#{ttl}"}
+    ]
+
+    headers = if urgency, do: [{"urgency", Atom.to_string(urgency)} | headers], else: headers
+    headers = if topic, do: [{"topic", topic} | headers], else: headers
+
     case Req.run(
       method: :post,
       url: endpoint,
       body: encrypted_payload.ciphertext,
-      headers: [
-        {"authorization", "WebPush #{signed_json_web_token}"},
-        {"content-encoding", "aesgcm"},
-        {"content-length", "#{byte_size(encrypted_payload.ciphertext)}"},
-        {"content-type", "application/octet-stream"},
-        {"crypto-key", "dh=#{url_encode(encrypted_payload.local_public_key)};p256ecdsa=#{url_encode(vapid_public_key)}"},
-        {"encryption", "salt=#{url_encode(encrypted_payload.salt)}"},
-        {"ttl", "60"}
-      ]
+      headers: headers
     ) do
       {request, %{status: status} = response} when status in 200..202 ->
         {:ok, Map.put(response, :request, request)}

--- a/test/web_push_elixir_test.exs
+++ b/test/web_push_elixir_test.exs
@@ -1,10 +1,16 @@
 defmodule WebPushElixirTest do
   use ExUnit.Case
 
+  @test_subscription %{
+    "endpoint" => "http://localhost:4040/some-push-service",
+    "keys" => %{
+      "p256dh" => "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=",
+      "auth" => "tBHItJI5svbpez7KI4CCXg=="
+      }
+    }
+
   test "it should send notification" do
-      subscription = """
-      {"endpoint":"http://localhost:4040/some-push-service","keys":{"p256dh":"BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=","auth":"tBHItJI5svbpez7KI4CCXg=="}}
-      """
+    subscription = Jason.encode!(@test_subscription)
 
     {:ok, response} = WebPushElixir.send_notification(subscription, "some message")
 
@@ -21,19 +27,39 @@ defmodule WebPushElixirTest do
     assert response.status in 200..202
   end
 
+  test "it should respect the custom ttl argument" do
+    subscription = Jason.encode!(@test_subscription)
+
+    {:ok, response} = WebPushElixir.send_notification(subscription, "some message", ttl: 300)
+
+    assert ["300"] = Map.get(response.request.headers, "ttl")
+  end
+
+  test "it should send the urgency parameter" do
+    subscription = Jason.encode!(@test_subscription)
+
+    {:ok, response} = WebPushElixir.send_notification(subscription, "some message", urgency: :high)
+
+    assert ["high"] = Map.get(response.request.headers, "urgency")
+  end
+
+  test "it should set the topic if it is provided" do
+    subscription = Jason.encode!(@test_subscription)
+
+    {:ok, response} = WebPushElixir.send_notification(subscription, "some message", topic: "some-test-topic")
+
+    assert ["some-test-topic"] = Map.get(response.request.headers, "topic")
+  end
 
   test "it should return expired" do
-    expired_subscription = """
-    {"endpoint":"http://localhost:4040/gone","keys":{"p256dh":"BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=","auth":"tBHItJI5svbpez7KI4CCXg=="}}
-    """
+    expired_subscription = Jason.encode!(%{@test_subscription | "endpoint" => "http://localhost:4040/gone"})
 
     assert {:error, :expired} = WebPushElixir.send_notification(expired_subscription, "message")
   end
 
   test "it should return http error" do
-    error_subscription = """
-    {"endpoint":"http://localhost:4040/error","keys":{"p256dh":"BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=","auth":"tBHItJI5svbpez7KI4CCXg=="}}
-    """
+
+    error_subscription = Jason.encode!(%{@test_subscription | "endpoint" => "http://localhost:4040/error"})
 
     assert {:error, {:http_error, status, _body}} = WebPushElixir.send_notification(error_subscription, "message")
     assert status != 200..202


### PR DESCRIPTION
To allow controlling more options for message delivery defined by the standard add the optional parameters and make them configurable per message.

Would be great to merge this, also fixes #1 